### PR TITLE
Read file in binary mode for encoding detection

### DIFF
--- a/lektor_htmlmin.py
+++ b/lektor_htmlmin.py
@@ -42,7 +42,7 @@ class HTMLMinPlugin(Plugin):
         """
         Minifies the target html file.
         """
-        enc = chardet.detect(open(target).read())['encoding']
+        enc = chardet.detect(open(target, 'rb').read())['encoding']
         f = codecs.open(target, 'r+', enc)
         result = htmlmin.minify(f.read(), **self.options)
         f.seek(0)


### PR DESCRIPTION
This otherwise does not work on Python 3 where chardet requires a binary
array rather than a unicode string.
