### PR TITLE
Add build flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ lektor-htmlmin = 0.2
 ```
 
 ## Usage
-When the build command is run, lektor-htmlmin will automatically minify .html files in the build destination
-folder, after lektor has finished building them.
-The original files will be overwritten by their minified counterpart.
+
+To enable minification, pass the `htmlmin` flag when starting the development server or when running a build:
 
 ```
-lektor build -O my_build_folder
+lektor build -O my_build_folder -f htmlmin
 ```
+
+When the flag is present, htmlmin will overwrite all HTML files in the output directory with their minified counterparts.
+
+*Note:* The htmlmin plugin currently minfies every file in the project after a build. Not just files that have been changed. This should have no ill effects, but might increase build times if there are many files to minify.

--- a/lektor_htmlmin.py
+++ b/lektor_htmlmin.py
@@ -22,13 +22,12 @@ class HTMLMinPlugin(Plugin):
             'reduce_boolean_attributes': False,
             'remove_optional_attribute_quotes': False,
             'keep_pre': False,
-            'pre_attr':'pre',
+            'pre_attr': 'pre',
             'remove_comments': True
         }
 
     def is_enabled(self, build_flags):
         return bool(build_flags.get('htmlmin'))
-
 
     def find_html_files(self, destination):
         """
@@ -38,7 +37,6 @@ class HTMLMinPlugin(Plugin):
             for f in files:
                 if f.endswith('.html'):
                     yield os.path.join(root, f)
-
 
     def minify_file(self, target):
         """
@@ -50,7 +48,6 @@ class HTMLMinPlugin(Plugin):
             f.seek(0)
             f.write(result)
             f.truncate()
-
 
     def on_after_build_all(self, builder, **extra):
         """

--- a/lektor_htmlmin.py
+++ b/lektor_htmlmin.py
@@ -25,6 +25,10 @@ class HTMLMinPlugin(Plugin):
             'remove_comments': True
         }
 
+    def is_enabled(self, build_flags):
+        return bool(build_flags.get('htmlmin'))
+
+
     def find_html_files(self, destination):
         """
         Finds all html files in the given destination.
@@ -55,6 +59,9 @@ class HTMLMinPlugin(Plugin):
         """
         after-build-all lektor event
         """
+        if not self.is_enabled(builder.build_flags):
+            return
+
         destination = builder.destination_path
         files = self.find_html_files(destination)
         for htmlfile in files:

--- a/lektor_htmlmin.py
+++ b/lektor_htmlmin.py
@@ -15,15 +15,15 @@ class HTMLMinPlugin(Plugin):
     def __init__(self, *args, **kwargs):
         Plugin.__init__(self, *args, **kwargs)
         self.options = {
-			'remove_empty_space': True,
-			'remove_all_empty_space': True,
-			'reduce_empty_attributes': True,
-			'reduce_boolean_attributes': False,
-			'remove_optional_attribute_quotes': False,
-			'keep_pre': False,
+            'remove_empty_space': True,
+            'remove_all_empty_space': True,
+            'reduce_empty_attributes': True,
+            'reduce_boolean_attributes': False,
+            'remove_optional_attribute_quotes': False,
+            'keep_pre': False,
             'pre_attr':'pre',
             'remove_comments': True
-		}
+        }
 
     def find_html_files(self, destination):
         """

--- a/lektor_htmlmin.py
+++ b/lektor_htmlmin.py
@@ -6,6 +6,7 @@ import chardet
 
 import htmlmin
 from lektor.pluginsystem import Plugin
+from lektor.reporter import reporter
 
 
 class HTMLMinPlugin(Plugin):
@@ -62,7 +63,9 @@ class HTMLMinPlugin(Plugin):
         if not self.is_enabled(builder.build_flags):
             return
 
+        reporter.report_generic('Starting HTML minification')
         destination = builder.destination_path
         files = self.find_html_files(destination)
         for htmlfile in files:
             self.minify_file(htmlfile)
+        reporter.report_generic('HTML minification finished')


### PR DESCRIPTION
I'd like to suggest that the plugin be enabled/disabled with a command line flag using `-f htmlmin`. This would make it behave the same way as the webpack plugin, and it makes it easy to not minify during development.

I also made some small whitespace / style / simplification changes at the same time.

Backstory: I have a lektor project with about 8000 documents, which takes 20+ minutes to minify. That's OK during a build, but not when running `lektor server` and developing.  Especially since the current behaviour is to minify every file, not just changed ones at the end of builds.
